### PR TITLE
Supporting module-as-command syntax ("python -m avrogen")

### DIFF
--- a/avrogen/__main__.py
+++ b/avrogen/__main__.py
@@ -1,0 +1,22 @@
+"""Usage:
+  python -m avrogen /path/to/protocol.avdl [-o /path/to/output]
+"""
+
+from .protocol import write_protocol_files
+from os.path import join
+from sys import argv
+
+def main():
+
+	if "-o" in argv:
+		avdl, _, output = argv[1:]
+	else:
+		avdl, output = argv[1], './'
+	write_protocol_files(open(avdl, 'r').read(), output)
+
+if __name__ == '__main__':
+	try:
+		exit(main())
+	except Exception:
+		print(__doc__)
+		raise


### PR DESCRIPTION
Modules such as ```json``` support a useful syntax for running some core function of the module directly from the command line; this PR adds a first implementation of this capability to avrogen via a module main file. It exposes the ```write_protocol_files``` function in ```protocol.py``` to convert JSON schemas to Python classes.

    python -m avrogen /path/to/my/avpr/file [-o /output/path]