### PR TITLE
Series of fixes making Avro Gen more useable

### DIFF
--- a/avrogen/core_writer.py
+++ b/avrogen/core_writer.py
@@ -39,14 +39,10 @@ def clean_fullname(fullname):
 
 def convert_default(full_name, idx, do_json=True):
     if do_json:
-        return ('_json_converter.from_json_object(SchemaClasses.{full_name}Class.RECORD_SCHEMA.fields[{idx}].default,'
-               + ' writers_schema=SchemaClasses.{full_name}Class.RECORD_SCHEMA.fields[{idx}].type)').format(
-            full_name=full_name, idx=idx
-        )
+        return (f'_json_converter.from_json_object({full_name}Class.RECORD_SCHEMA.fields[{idx}].default,'
+               + f' writers_schema={full_name}Class.RECORD_SCHEMA.fields[{idx}].type)')
     else:
-        return ('SchemaClasses.{full_name}Class.RECORD_SCHEMA.fields[{idx}].default').format(
-            full_name=full_name, idx=idx
-        )
+        return f'{full_name}Class.RECORD_SCHEMA.fields[{idx}].default'
 
 
 def write_defaults(record, writer, my_full_name=None, use_logical_types=False):
@@ -71,51 +67,46 @@ def write_defaults(record, writer, my_full_name=None, use_logical_types=False):
             if use_logical_types and default_type.props.get('logicalType') \
                     and default_type.props.get('logicalType') in logical.DEFAULT_LOGICAL_TYPES:
                 lt = logical.DEFAULT_LOGICAL_TYPES[default_type.props.get('logicalType')]
-
-                writer.write(
-                    '\nself.{name} = {value}'
-                        .format(name=f_name,
-                                value=lt.initializer(convert_default(my_full_name, idx=i,
-                                                                     do_json=isinstance(default_type,
-                                                                                        schema.RecordSchema)))))
+                v = lt.initializer(convert_default(my_full_name,
+                                                   idx=i,
+                                                   do_json=isinstance(default_type,
+                                                   schema.RecordSchema)))
+                writer.write(f'\nself.{f_name} = {v}')
                 default_written = True
             elif isinstance(default_type, schema.RecordSchema):
-                writer.write(
-                    '\nself.{name} = {full_name}Class({default})'
-                        .format(name=f_name, full_name=field.name,
-                                default=convert_default(idx=i, full_name=my_full_name, do_json=True)))
+                d = convert_default(idx=i, full_name=my_full_name, do_json=True)
+                writer.write(f'\nself.{f_name} = {field.name}Class({d})')
                 default_written = True
             elif isinstance(default_type, (schema.PrimitiveSchema, schema.EnumSchema, schema.FixedSchema)):
-                writer.write('\nself.{name} = {default}'
-                             .format(name=f_name, default=convert_default(full_name=my_full_name, idx=i,
-                                                                              do_json=False)))
+                d = convert_default(full_name=my_full_name, idx=i, do_json=False)
+                writer.write(f'\nself.{f_name} = {d}')
                 default_written = True
 
         if not default_written:
             default_written = True
             if nullable:
-                writer.write('\nself.{name} = None'.format(name=f_name))
+                writer.write(f'\nself.{f_name} = None')
             elif use_logical_types and default_type.props.get('logicalType') \
                     and default_type.props.get('logicalType') in logical.DEFAULT_LOGICAL_TYPES:
                 lt = logical.DEFAULT_LOGICAL_TYPES[default_type.props.get('logicalType')]
-                writer.write('\nself.{name} = {default}'.format(name=f_name,
+                writer.write('\nself.{f_name} = {default}'.format(name=f_name,
                                                                 default=lt.initializer()))
             elif isinstance(default_type, schema.PrimitiveSchema) and not default_type.props.get('logicalType'):
-                writer.write('\nself.{name} = {default}'.format(name=f_name,
-                                                                default=get_primitive_field_initializer(default_type)))
+                d = get_primitive_field_initializer(default_type)
+                writer.write(f'\nself.{f_name} = {d}')
             elif isinstance(default_type, schema.EnumSchema):
-                writer.write('\nself.{name} = {full_name}Class.{sym}'
-                             .format(name=f_name, full_name=clean_fullname(default_type.name),
-                                     sym=default_type.symbols[0]))
+                f = clean_fullname(default_type.name)
+                s = default_type.symbols[0]
+                writer.write(f'\nself.{f_name} = {f}Class.{s}')
             elif isinstance(default_type, schema.MapSchema):
-                writer.write('\nself.{name} = dict()'.format(name=f_name))
+                writer.write(f'\nself.{f_name} = dict()')
             elif isinstance(default_type, schema.ArraySchema):
-                writer.write('\nself.{name} = list()'.format(name=f_name))
+                writer.write(f'\nself.{f_name} = list()')
             elif isinstance(default_type, schema.FixedSchema):
-                writer.write('\nself.{name} = str()'.format(name=f_name))
+                writer.write(f'\nself.{f_name} = str()')
             elif isinstance(default_type, schema.RecordSchema):
-                writer.write('\nself.{name} = {full_name}Class()'
-                             .format(name=f_name, full_name=clean_fullname(default_type.name)))
+                f = clean_fullname(default_type.name)
+                writer.write(f'\nself.{f_name} = {f}Class()')
             else:
                 default_written = False
         something_written = something_written or default_written
@@ -265,7 +256,7 @@ def write_preamble(writer, use_logical_types, custom_imports):
     writer.write('import six\n')
 
     for cs in (custom_imports or []):
-        writer.write('import %s\n' % cs)
+        writer.write(f'import {cs}\n')
     writer.write('from avrogen.dict_wrapper import DictWrapper\n')
     writer.write('from avrogen import avrojson\n')
     if use_logical_types:

--- a/avrogen/core_writer.py
+++ b/avrogen/core_writer.py
@@ -140,14 +140,14 @@ def write_field(field, writer, use_logical_types):
     writer.write('''
 @property
 def {name}(self) -> {ret_type_name}:
-    return self._inner_dict.get('{field.name}')
+    return self._inner_dict.get('{raw_name}')
 
 
 @{name}.setter
 def {name}(self, value: {ret_type_name}):
-    self._inner_dict['{field.name}'] = value
+    self._inner_dict['{raw_name}'] = value
 
-'''.format(name=name, ret_type_name=get_field_type_name(field.type, use_logical_types)))
+'''.format(name=name, raw_name=field.name, ret_type_name=get_field_type_name(field.type, use_logical_types)))
 
 
 def get_primitive_field_initializer(field_schema):

--- a/avrogen/core_writer.py
+++ b/avrogen/core_writer.py
@@ -140,12 +140,12 @@ def write_field(field, writer, use_logical_types):
     writer.write('''
 @property
 def {name}(self) -> {ret_type_name}:
-    return self._inner_dict.get('{name}')
+    return self._inner_dict.get('{field.name}')
 
 
 @{name}.setter
 def {name}(self, value: {ret_type_name}):
-    self._inner_dict['{name}'] = value
+    self._inner_dict['{field.name}'] = value
 
 '''.format(name=name, ret_type_name=get_field_type_name(field.type, use_logical_types)))
 

--- a/avrogen/core_writer.py
+++ b/avrogen/core_writer.py
@@ -68,7 +68,7 @@ def write_defaults(record, writer, my_full_name=None, use_logical_types=False):
                     and default_type.props.get('logicalType') in logical.DEFAULT_LOGICAL_TYPES:
                 lt = logical.DEFAULT_LOGICAL_TYPES[default_type.props.get('logicalType')]
                 v = lt.initializer(convert_default(my_full_name,
-                                                   idx=f_name,
+                                                   idx=i,
                                                    do_json=isinstance(default_type,
                                                    schema.RecordSchema)))
                 writer.write(f'\nself.{f_name} = {v}')
@@ -78,7 +78,7 @@ def write_defaults(record, writer, my_full_name=None, use_logical_types=False):
                 writer.write(f'\nself.{f_name} = {field.name}Class({d})')
                 default_written = True
             elif isinstance(default_type, (schema.PrimitiveSchema, schema.EnumSchema, schema.FixedSchema)):
-                d = convert_default(full_name=my_full_name, idx=i, do_json=False)
+                d = convert_default(full_name=my_full_name, idx=f_name, do_json=False)
                 writer.write(f'\nself.{f_name} = {d}')
                 default_written = True
 

--- a/avrogen/core_writer.py
+++ b/avrogen/core_writer.py
@@ -42,7 +42,7 @@ def convert_default(full_name, idx, do_json=True):
         return (f'_json_converter.from_json_object({full_name}Class.RECORD_SCHEMA.fields[{idx}].default,'
                + f' writers_schema={full_name}Class.RECORD_SCHEMA.fields[{idx}].type)')
     else:
-        return f'{full_name}Class.RECORD_SCHEMA.fields[{idx}].default'
+        return f'self.RECORD_SCHEMA.fields[{idx}].default'
 
 
 def write_defaults(record, writer, my_full_name=None, use_logical_types=False):

--- a/avrogen/core_writer.py
+++ b/avrogen/core_writer.py
@@ -257,6 +257,7 @@ def write_preamble(writer, use_logical_types, custom_imports):
     :param  writer:
     :return:
     """
+    writer.write('from __future__ import annotations\n')
     writer.write('import json\n')
     writer.write('import os.path\n')
     writer.write('import decimal\n')
@@ -272,7 +273,6 @@ def write_preamble(writer, use_logical_types, custom_imports):
     writer.write('from avro.schema import SchemaFromJSONData as make_avsc_object\n')
     writer.write('from avro import schema as avro_schema\n')
     writer.write('from typing import List, Dict\n')
-    writer.write('from __future__ import annotations\n')
     writer.write('\n')
 
 
@@ -314,7 +314,7 @@ def write_reader_impl(record_types, writer, use_logical_types):
         writer.write('\nSCHEMA_TYPES = {')
         with writer.indent():
             for t in record_types:
-                writer.write('\n"{t_class}": {t_class}Class,'.format(t_class=t.split('.')[1]))
+                writer.write('\n"{t_class}": {t_class}Class,'.format(t_class=t.split('.')[-1]))
 
         writer.write('\n}')
         writer.write('\n\n\ndef __init__(self, readers_schema=None, **kwargs):')

--- a/avrogen/core_writer.py
+++ b/avrogen/core_writer.py
@@ -42,7 +42,7 @@ def convert_default(full_name, idx, do_json=True):
         return (f'_json_converter.from_json_object({full_name}Class.RECORD_SCHEMA.fields[{idx}].default,'
                + f' writers_schema={full_name}Class.RECORD_SCHEMA.fields[{idx}].type)')
     else:
-        return f'self.RECORD_SCHEMA.fields[{idx}].default'
+        return f'SCHEMA.field_map["{idx}"].default'
 
 
 def write_defaults(record, writer, my_full_name=None, use_logical_types=False):
@@ -68,7 +68,7 @@ def write_defaults(record, writer, my_full_name=None, use_logical_types=False):
                     and default_type.props.get('logicalType') in logical.DEFAULT_LOGICAL_TYPES:
                 lt = logical.DEFAULT_LOGICAL_TYPES[default_type.props.get('logicalType')]
                 v = lt.initializer(convert_default(my_full_name,
-                                                   idx=i,
+                                                   idx=f_name,
                                                    do_json=isinstance(default_type,
                                                    schema.RecordSchema)))
                 writer.write(f'\nself.{f_name} = {v}')
@@ -103,7 +103,7 @@ def write_defaults(record, writer, my_full_name=None, use_logical_types=False):
             elif isinstance(default_type, schema.ArraySchema):
                 writer.write(f'\nself.{f_name} = list()')
             elif isinstance(default_type, schema.FixedSchema):
-                writer.write(f'\nself.{f_name} = str()')
+                writer.write(f'\nself.{f_name}: str = str()')
             elif isinstance(default_type, schema.RecordSchema):
                 f = clean_fullname(default_type.name)
                 writer.write(f'\nself.{f_name} = {f}Class()')

--- a/avrogen/dict_wrapper.py
+++ b/avrogen/dict_wrapper.py
@@ -29,7 +29,7 @@ if six.PY3:
         def values(self):
             return self._inner_dict.values()
 
-        def fromkeys(S, v=None):
+        def fromkeys(self, v=None):
             raise NotImplementedError
 
         def clear(self):
@@ -132,7 +132,7 @@ else:
         def viewvalues(self):
             return self._inner_dict.viewvalues()
 
-        def fromkeys(S, v=None):
+        def fromkeys(self, v=None):
             raise NotImplementedError
 
         def clear(self):
@@ -145,7 +145,7 @@ else:
             return self._inner_dict.get(k, d)
 
         def has_key(self, k):
-            return self._inner_dict.has_key(key)
+            return self._inner_dict.has_key(k)
 
         def __contains__(self, item):
             return self._inner_dict.__contains__(item)

--- a/avrogen/schema.py
+++ b/avrogen/schema.py
@@ -63,14 +63,14 @@ def generate_schema(schema_json, use_logical_types=False, custom_imports=None, a
             logger.debug('Writing enum: %s', field_schema.fullname)
             write_enum(field_schema, writer)
     writer.set_tab(0)
-    writer.write('\n__SCHEMA_TYPES = {\n')
+    writer.write('\n__SCHEMA_TYPES = {')
     writer.tab()
 
     for name, field_schema in names:
-        writer.write("'%s': %sClass,\n" % (clean_fullname(field_schema.name), clean_fullname(field_schema.name)))
+        writer.write("\n'%s': %sClass," % (clean_fullname(field_schema.name), clean_fullname(field_schema.name)))
 
     writer.untab()
-    writer.write('\n}\n')
+    writer.write('\n}\n\n')
 
     writer.write('_json_converter = %s\n\n' % avro_json_converter)
 

--- a/avrogen/schema.py
+++ b/avrogen/schema.py
@@ -4,16 +4,10 @@ import os
 import six
 from avro import schema
 
-if six.PY3:
-    from io import StringIO
-else:
-    from cStringIO import StringIO
+from io import StringIO
 
 
-if six.PY3:
-    from avro.schema import SchemaFromJSONData as make_avsc_object
-else:
-    from avro.schema import make_avsc_object
+from avro.schema import SchemaFromJSONData as make_avsc_object
 
 from .core_writer import generate_namespace_modules, clean_fullname
 from .tabbed_writer import TabbedWriter
@@ -55,17 +49,12 @@ def generate_schema(schema_json, use_logical_types=False, custom_imports=None, a
     write_get_schema(writer)
     write_populate_schemas(writer)
 
-    writer.write('\n\n\nclass SchemaClasses(object):')
-    writer.tab()
-    writer.write('\n\n')
-
     current_namespace = tuple()
 
     for name, field_schema in names:  # type: str, schema.Schema
         name = clean_fullname(name)
         namespace = tuple(name.split('.')[:-1])
         if namespace != current_namespace:
-            start_namespace(current_namespace, namespace, writer)
             current_namespace = namespace
         if isinstance(field_schema, schema.RecordSchema):
             logger.debug('Writing schema: %s', clean_fullname(field_schema.fullname))
@@ -73,13 +62,12 @@ def generate_schema(schema_json, use_logical_types=False, custom_imports=None, a
         elif isinstance(field_schema, schema.EnumSchema):
             logger.debug('Writing enum: %s', field_schema.fullname)
             write_enum(field_schema, writer)
-    writer.write('\npass\n')
     writer.set_tab(0)
     writer.write('\n__SCHEMA_TYPES = {\n')
     writer.tab()
 
     for name, field_schema in names:
-        writer.write("'%s': SchemaClasses.%sClass,\n" % (clean_fullname(field_schema.fullname), clean_fullname(field_schema.fullname)))
+        writer.write("'%s': %sClass,\n" % (clean_fullname(field_schema.name), clean_fullname(field_schema.name)))
 
     writer.untab()
     writer.write('\n}\n')
@@ -104,7 +92,7 @@ def write_schema_preamble(writer):
         writer.write('\nnames = avro_schema.Names()')
         writer.write('\nschema = make_avsc_object(json.loads(__read_file(file_name)), names)')
         writer.write('\nreturn names, schema')
-    writer.write('\n\n__NAMES, SCHEMA = __get_names_and_schema(os.path.join(os.path.dirname(__file__), "schema.avsc"))')
+    writer.write('\n\n\n__NAMES, SCHEMA = __get_names_and_schema(os.path.join(os.path.dirname(__file__), "schema.avsc"))')
 
 
 def write_populate_schemas(writer):
@@ -129,9 +117,13 @@ def write_namespace_modules(ns_dict, output_folder):
             currency = '.'
             if ns != '':
                 currency += '.' * len(ns.split('.'))
-            f.write('from {currency}schema_classes import SchemaClasses\n'.format(currency=currency))
             for name in ns_dict[ns]:
-                f.write("{name} = SchemaClasses.{ns}{name}Class\n".format(name=name, ns=ns if not ns else (ns + ".")))
+                f.write('from {0}schema_classes import {1}Class\n'.format(currency, name))
+
+            f.write('\n\n')
+
+            for name in ns_dict[ns]:
+                f.write("{name} = {name}Class\n".format(name=name))
 
 
 def write_specific_reader(record_types, output_folder, use_logical_types):
@@ -143,7 +135,9 @@ def write_specific_reader(record_types, output_folder, use_logical_types):
     """
     with open(os.path.join(output_folder, "__init__.py"), "a+") as f:
         writer = TabbedWriter(f)
-        writer.write('\n\nfrom .schema_classes import SchemaClasses, SCHEMA as my_schema, get_schema_type')
+        writer.write('from .schema_classes import SCHEMA as get_schema_type')
+        for t in record_types:
+            writer.write('\nfrom .schema_classes import {}Class'.format(t.split('.')[1]))
         writer.write('\nfrom avro.io import DatumReader')
         if use_logical_types:
             writer.write('\nfrom avrogen import logical')

--- a/avrogen/schema.py
+++ b/avrogen/schema.py
@@ -101,7 +101,7 @@ def write_populate_schemas(writer):
     :param writer:
     :return:
     """
-    writer.write('\n__SCHEMAS = dict((n.fullname.lstrip("."), n) for n in six.itervalues(__NAMES.names))')
+    writer.write('\n__SCHEMAS = dict((n.fullname.lstrip("."), n) for n in six.itervalues(__NAMES.names))\n')
 
 
 def write_namespace_modules(ns_dict, output_folder):
@@ -118,7 +118,7 @@ def write_namespace_modules(ns_dict, output_folder):
             if ns != '':
                 currency += '.' * len(ns.split('.'))
             for name in ns_dict[ns]:
-                f.write('from {0}schema_classes import {1}Class\n'.format(currency, name))
+                f.write(f'from {currency}schema_classes import {name}Class\n')
 
             f.write('\n\n')
 
@@ -136,8 +136,9 @@ def write_specific_reader(record_types, output_folder, use_logical_types):
     with open(os.path.join(output_folder, "__init__.py"), "a+") as f:
         writer = TabbedWriter(f)
         writer.write('from .schema_classes import SCHEMA as get_schema_type')
+        print(record_types)
         for t in record_types:
-            writer.write('\nfrom .schema_classes import {}Class'.format(t.split('.')[1]))
+            writer.write('\nfrom .schema_classes import {}Class'.format(t.split('.')[-1]))
         writer.write('\nfrom avro.io import DatumReader')
         if use_logical_types:
             writer.write('\nfrom avrogen import logical')


### PR DESCRIPTION
This series of commits brings avrogen up to standard with typehinting, fixes for avro schemas that have names that match python keywords and creates classes in a flat structure, so that both multi and mono repos have easier access to the classes themselves.